### PR TITLE
Updated seed values feature

### DIFF
--- a/apps/extension/package-lock.json
+++ b/apps/extension/package-lock.json
@@ -853,6 +853,8 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
             "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -868,7 +870,9 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -5111,15 +5115,14 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "dev": true,
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.8.2",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
                     "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
                     "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -5131,7 +5134,9 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true,
+                    "peer": true
                 }
             }
         },

--- a/packages/age5/src/maintenance/features/seed-values.feature.ts
+++ b/packages/age5/src/maintenance/features/seed-values.feature.ts
@@ -13,10 +13,10 @@ export async function seedValuesFeature(): Promise<void> {
     const stocks: Stocks = await stocksRepo.getOwn();
     const processingStocks: Stocks = await stocksRepo.getOwnProcessingStocks();
 
-    getValueCell(rows[17]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.TREE)));
-    getValueCell(rows[18]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.BUSH)));
-    getValueCell(rows[19]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.FLOWER)));
-    getValueCell(rows[20]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.GRASS)));
+    getValueCell(rows[18]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.TREE)));
+    getValueCell(rows[19]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.BUSH)));
+    getValueCell(rows[20]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.FLOWER)));
+    getValueCell(rows[21]).appendChild(SeedInformationComponentFactory(Seeds.FilterForCropType(stocks.seeds, CropType.GRASS)));
 
     if (processingStocks.seeds.total > 0) {
         rows[rows.length - 1].children[0].appendChild(SeedInformationComponentFactory(processingStocks.seeds));


### PR DESCRIPTION
The addition of the `Plant All` button on the maintenance page introduced an extra table row that put the seed values buttons off by 1. I believe that the changes here should fix that. I haven't tested this in the browser as I'm not sure how to do that.

![image](https://user-images.githubusercontent.com/16706554/144476422-df63fcd9-c55a-4644-b0f2-971c3c85ee96.png)
 